### PR TITLE
start.sh: Added sleep time because logs printed right after start up are lost due to race condition

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+sleep 1s
 python server.py &
 for ((i=1;i<=5;i++));
 do


### PR DESCRIPTION
@lifeeth 

[Connects to resin-io/resin-supervisor#23]

Signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>