### PR TITLE
Use python3 venv which is recommended for adhering with PEP 668.

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -14,4 +14,3 @@ jobs:
       (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
     secrets: inherit
-    with: {}

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,10 +1,12 @@
 FROM balenalib/%%RESIN_MACHINE_NAME%%-alpine:latest
 
-RUN apk update && apk add bash py-pip lockfile-progs --no-cache && \
+WORKDIR /usr/src/app
+
+RUN apk update && apk add bash python3 lockfile-progs --no-cache && \
+    python3 -m venv venv && \
+    source venv/bin/activate && \
     pip install --upgrade pip && \
     pip install flask
-
-WORKDIR /usr/src/app
 
 COPY . ./
 

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+source venv/bin/activate
+
 python server.py &
 for ((i=1;i<=5;i++));
 do


### PR DESCRIPTION
Starting alpine:3.19 with py3-pip v23.3.1-r0, py3-pip installations using apk will cause the error `error: externally-managed-environment` when pip attempts to upgrade the pip installation.  We now use a virtual env for the test app to avoid this issue.

Change-type: patch