### PR TITLE
start.sh: Print the target message forever

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -3,13 +3,8 @@
 source venv/bin/activate
 
 python server.py &
-for ((i=1;i<=5;i++));
-do
-    cat <message.txt
-    sleep 1s
-done
-while true
-do
-    echo "Running..."
-    sleep 60s
+
+while true; do
+	cat <message.txt
+	sleep 5s
 done


### PR DESCRIPTION
The log streaming does not guarantee a start time, so to avoid missing early container logs during other checks we need to log the target message forever.

Change-type: patch
See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/e2e-failures-Checking-if-device-is-running-the-latest-release-173